### PR TITLE
Small fix and alternative summary source

### DIFF
--- a/app/config/podcast_config_parser.py
+++ b/app/config/podcast_config_parser.py
@@ -146,7 +146,7 @@ class PodcastConfigParser:
             )
 
             new_item["episode_count"] = p.get(
-                "deepisode_countlay", DEFAULT_PODCAST_EPISODE_COUNT
+                "episode_count", DEFAULT_PODCAST_EPISODE_COUNT
             )
 
             output.append(new_item)

--- a/app/rssextractor.py
+++ b/app/rssextractor.py
@@ -90,6 +90,8 @@ class RSSExtractor(Thread):
                         ep = Episode()
                         ep.title = episode_info["title"]
                         ep.summary = episode_info.get("summary", "")
+                        if(not ep.summary):
+                           ep.summary = episode_info.get("alt_title", "")
                         ep.media = Media
 
                         request = urllib.request.Request(


### PR DESCRIPTION
* Fix for the episode_count config value not correctly loaded from podcast configs
* Added 'alt_title' as alternative summary from info, if 'summary' is empty